### PR TITLE
fix hyphen problem.

### DIFF
--- a/app/parser.js
+++ b/app/parser.js
@@ -1,5 +1,5 @@
 var SECTION = /\[([^#\]]*)(#+)?\]/;
-var END_OF_SEES = /-+/;
+var END_OF_SEES = /^-+/;
 var END_OF_ACTION = /=+(?:{([^}]+)})?=+>\s*([^:\]]*)/;
 var WHITE_LINE = /^\s*$/;
 


### PR DESCRIPTION
テキストの中に "-" があるとコケてたので直しました。

NG例

```
[ほげ]
ほげほげする画面
--
ボタン - ほげほげ
```
